### PR TITLE
fix: update TypeScript ESLint parser package names (TOOLS-684)

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -1,25 +1,26 @@
 'use strict';
 
 module.exports = {
-	'parser': 'typescript-eslint-parser',
+	'parser': '@typescript-eslint/parser',
 	'extends': '6river',
 	'plugins': [
-		'typescript',
+		'@typescript-eslint',
 		'6river'
 	],
 	'rules': {
 		'no-undef': 'off',
 		"no-unused-vars": "off",
-		"typescript/no-unused-vars": "error",
-		'typescript/no-triple-slash-reference': 'error',
+		"@typescript-eslint/no-unused-vars": "error",
+		'@typescript-eslint/no-triple-slash-reference': 'error',
 		'new-cap': 'off',
 		'6river/new-cap': [
 			'error', {
 				'capIsNewExceptionPattern': '^@'
 			}
+
 		],
 		"valid-jsdoc": "off",
-		"typescript/type-annotation-spacing": "error"
+		"@typescript-eslint/type-annotation-spacing": "error"
 	},
 	'parserOptions': {
 		'ecmaVersion': 6,


### PR DESCRIPTION
- fix: update TypeScript ESLint parser package names
  BREAKING CHANGE:
  Requires `@typescript-eslint/eslint-plugin` and
  `@typescript-eslint/parser` (instead of the old packages,
  `typescript-eslint-plugin` and `typescript-eslint-parser`).