### PR TITLE
fix(typescript): update triple slash reference rule name (TOOLS-1080)

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -11,7 +11,7 @@ module.exports = {
 		'no-undef': 'off',
 		"no-unused-vars": "off",
 		"@typescript-eslint/no-unused-vars": "error",
-		'@typescript-eslint/no-triple-slash-reference': 'error',
+		'@typescript-eslint/triple-slash-reference': 'error',
 		'new-cap': 'off',
 		'6river/new-cap': [
 			'error', {


### PR DESCRIPTION
- fix(typescript): update triple slash reference rule name
  BREAKING CHANGE:
  [`typescript-eslint` 2.0.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v2.0.0) changes the name of the `no-triple-slash-reference` to `triple-slash-reference`. When updating your version of `eslint-config-6river`, make sure to also update `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`.