### PR TITLE
separate builtin imports from external libraries

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ const config = {
 			'error',
 			{
 				'groups': [
-					['builtin', 'external'],
+					['builtin'],
+					['external'],
 					['internal', 'parent', 'sibling', 'index'],
 				],
 				'newlines-between': 'always',


### PR DESCRIPTION
This change separates NodeJS builtins and dependency libraries (externals) into two separate groups. Without this change, the are grouped together in the same block, which is fine, but they are also sorted alphabetically, which results in code like this:

```
import { Injectable, Inject } from '@nestjs/common';
import * as chokidar from 'chokidar';
import { promises as fs, Stats } from 'fs';
import { PinoLogger, InjectPinoLogger } from 'nestjs-pino';
```

After this change this the imports would look like the following (note the Node builtins are presented before the external dependencies:

```
import { promises as fs, Stats } from 'fs';

import { Injectable, Inject } from '@nestjs/common';
import * as chokidar from 'chokidar';
import { PinoLogger, InjectPinoLogger } from 'nestjs-pino';
```

Frontend apps don't have "builtins" so this change shouldn't affect them, but will make the lives of backend developers easier.

cc/ @AdamVig @mgabeler-lee-6rs 
