### PR TITLE
chore: ignore @6river/commitlint-config-6river updates (EXP-1148)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
   reviewers:
   - AdamVig
   versioning-strategy: widen
+  ignore:
+    - dependency-name: "@6river/commitlint-config-6river"


### PR DESCRIPTION
### Commits

- chore: ignore @6river/commitlint-config-6river updates
  This avoids a dependency update loop that would occur between this
  package and `@6river/commitlint-config-6river`.

  See https://github.com/6RiverSystems/commitlint-config-6river/pull/98.