### PR TITLE
fix: banning the ! operator is untenable for our code

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -9,6 +9,7 @@ module.exports = {
 		'@typescript-eslint/no-explicit-any': ['off'],
 		'@typescript-eslint/no-floating-promises': 'error',
 		'@typescript-eslint/no-namespace': 'off',
+		'@typescript-eslint/no-non-null-assertion': 'off',
 		'@typescript-eslint/no-unused-vars': 'error',
 		'@typescript-eslint/triple-slash-reference': 'error',
 		'@typescript-eslint/type-annotation-spacing': 'error',


### PR DESCRIPTION
We have lots of code where we use this because typescript's detection just isn't smart enough.