### PR TITLE
fix: base no-invalid-this is replaced by typescript one

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -19,6 +19,7 @@ module.exports = {
 		'no-undef': 'off',
 		'no-unused-vars': 'off',
 		'valid-jsdoc': 'off',
+		'no-invalid-this': 'off',
 	},
 	parserOptions: {
 		ecmaVersion: 6,


### PR DESCRIPTION
ref: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-invalid-this.md

the base eslint rule doesn't understand some typescript specifics, and thus fires false positives in several cases
