### PR TITLE
fix: restore dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,17 +34,18 @@
     "enforce",
     "hint"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "eslint-config-google": "^0.14.0",
+    "eslint-plugin-6river": "^1.0.6",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-mocha": "^10.0.5"
+  },
   "devDependencies": {
     "@6river/commitlint-config-6river": "^2.2.77",
     "@6river/prettier-config": "^1.0.63",
     "@commitlint/cli": "^17.0.3",
     "eslint": "^8.18.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-config-google": "^0.14.0",
-    "eslint-plugin-6river": "^1.0.6",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-mocha": "^10.0.5",
     "husky": "^8.0.1",
     "prettier": "^2.7.1"
   },


### PR DESCRIPTION
**Commits**
- fix: restore dependencies  
  These were inadvertently moved from `dependencies` to
  `devDependencies` in 702596ce0de5815b9a47198861b26260c2752b07 /
  https://github.com/6RiverSystems/eslint-config-6river/pull/206.