### PR TITLE
fix: make dependabot change package.json files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: '/'
+    directory: "/"
     schedule:
       interval: daily
     pull-request-branch-name:
-      separator: '-'
+      separator: "-"
     open-pull-requests-limit: 10
     reviewers:
       - AdamVig
-    versioning-strategy: widen
+    versioning-strategy: increase
     ignore:
-      - dependency-name: '@6river/commitlint-config-6river'
-      - dependency-name: '@6river/prettier-config'
+      - dependency-name: "@6river/commitlint-config-6river"
+      - dependency-name: "@6river/prettier-config"


### PR DESCRIPTION
With the `widen` strategy, dependabot was only ever modifying the
package-lock, which was mostly useless as it is only used for running the
(minimal) unit tests in this repo. We actually want it to push folks to
update their dependencies, so we need to use a more aggressive behavior.